### PR TITLE
Add requires option to credo config

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -2,6 +2,7 @@
   configs: [
     %{
       name: "default",
+      requires: ["lib/"],
       checks: [
         {Credo.Check.Readability.ModuleDoc, false},
         {CredoDemoPlugin.BetterModuleDoc, []}


### PR DESCRIPTION
Since we didn't have the requires option in the credo config, the `CredoDemoPlugin.BetterModuleDoc` was ignored with the following message:

```
Ignoring an undefined check: CredoDemoPlugin.BetterModuleDoc
```

Now it works as expected! 😊